### PR TITLE
Fix endpoint prefixes & catch HTTP errors properly

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -78,11 +78,18 @@ module.exports = class Request {
 
     return new Promise((resolve, reject) => {
       request(options, function callback(error, response, body) {
-        if(!error && response.statusCode == 200) {
-          resolve(body);
-        } else if(error) {
-          reject(error);
+        if (error) {
+          return reject(error);
         }
+        if (response.statusCode == 200) {
+          return resolve(body);
+        }
+        return reject({
+          code: response.statusCode,
+          message: response.statusMessage,
+          body: response.body,
+          requestOptions: options
+        });
       });
     });
   }

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,6 +1,4 @@
-
 const assert = require('assert');
-
 const request = require('request');
 
 const {signMessage} = require('./utility.js');
@@ -31,7 +29,6 @@ module.exports = class Request {
     this.key = key;
     this.secret = secret;
   }
-
 
   async get(endpoint, params) {
     const result = await this._call('GET', endpoint, params);

--- a/lib/request.js
+++ b/lib/request.js
@@ -44,14 +44,14 @@ module.exports = class Request {
 
   async getTimeOffset() {
     const start = Date.now();
-    const result = await this.get('/v2/public/time');
+    const result = await this.get('v2/public/time');
     const end = Date.now();
 
     return Math.ceil((result.time_now * 1000) - end + ((end - start) / 2));
   }
 
   async _call(method, endpoint, params) {
-    const publicEndpoint = endpoint.startsWith('/v2/public');
+    const publicEndpoint = endpoint.startsWith('v2/public');
 
     if(!publicEndpoint) {
       if(!this.key || !this.secret) throw new Error('Private endpoints require api and private keys set');

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -19,11 +19,11 @@ module.exports = class RestClient {
 
     if(params.order_type === 'Limit') assert(params.price, 'Parameter price is required for limit orders');
 
-    return await this.request.post('/v2/private/order/create', params);
+    return await this.request.post('v2/private/order/create', params);
   }
 
   async getActiveOrder(params) {
-    return await this.request.get('/open-api/order/list', params);
+    return await this.request.get('open-api/order/list', params);
   }
 
   async cancelActiveOrder(params) {
@@ -31,14 +31,14 @@ module.exports = class RestClient {
     assert(params.symbol, 'Parameter symbol is required');
     assert(params.order_id || params.order_link_id, 'Parameter order_id OR order_link_id is required');
 
-    return await this.request.post('/v2/private/order/cancel', params);
+    return await this.request.post('v2/private/order/cancel', params);
   }
 
   async cancelAllActiveOrders(params) {
     assert(params, 'No params passed');
     assert(params.symbol, 'Parameter symbol is required');
 
-    return await this.request.post('/v2/private/order/cancelAll', params);
+    return await this.request.post('v2/private/order/cancelAll', params);
   }
 
   async replaceActiveOrder(params) {
@@ -46,7 +46,7 @@ module.exports = class RestClient {
     assert(params.order_id || params.order_link_id, 'Parameter order_id OR order_link_id is required');
     assert(params.symbol, 'Parameter symbol is required');
 
-    return await this.request.post('/open-api/order/replace', params);
+    return await this.request.post('open-api/order/replace', params);
   }
 
   async queryActiveOrder(params) {
@@ -54,7 +54,7 @@ module.exports = class RestClient {
     assert(params.order_id || params.order_link_id, 'Parameter order_id OR order_link_id is required');
     assert(params.symbol, 'Parameter symbol is required');
 
-    return await this.request.get('/v2/private/order', params);
+    return await this.request.get('v2/private/order', params);
   }
 
   async placeConditionalOrder(params) {
@@ -69,25 +69,25 @@ module.exports = class RestClient {
 
     if(params.order_type === 'Limit') assert(params.price, 'Parameter price is required for limit orders');
 
-    return await this.request.post('/open-api/stop-order/create', params);
+    return await this.request.post('open-api/stop-order/create', params);
   }
 
   async getConditioanlOrder(params) {
-    return await this.request.get('/open-api/stop-order/list', params);
+    return await this.request.get('open-api/stop-order/list', params);
   }
 
   async cancelConditionalOrder(params) {
     assert(params, 'No params passed');
     assert(params.stop_order_id, 'Parameter stop_order_id is required');
 
-    return await this.request.post('/open-api/stop-order/cancel', params);
+    return await this.request.post('open-api/stop-order/cancel', params);
   }
 
   async cancelAllConditionalOrders(params) {
     assert(params, 'No params passed');
     assert(params.symbol, 'Parameter symbol is required');
 
-    return await this.request.post('/v2/private/stop-order/cancelAll', params);
+    return await this.request.post('v2/private/stop-order/cancelAll', params);
   }
 
   async queryConditionalOrder(params) {
@@ -99,7 +99,7 @@ module.exports = class RestClient {
   }
 
   async getUserLeverage() {
-    return await this.request.get('/user/leverage');
+    return await this.request.get('user/leverage');
   }
 
   async changeUserLeverage(params) {
@@ -107,18 +107,18 @@ module.exports = class RestClient {
     assert(params.leverage, 'Parameter leverage is required');
     assert(params.symbol, 'Parameter symbol is required');
 
-    return await this.request.post('/user/leverage/save', params);
+    return await this.request.post('user/leverage/save', params);
   }
 
   async getPosition(params) {
     assert(params, 'No params passed');
     assert(params.symbol, 'Parameter symbol is required');
 
-    return await this.request.get('/v2/private/position/list', params);
+    return await this.request.get('v2/private/position/list', params);
   }
 
   async getPositions() {
-    return await this.request.get('/position/list');
+    return await this.request.get('position/list');
   }
 
   async changePositionMargin(params) {
@@ -126,28 +126,28 @@ module.exports = class RestClient {
     assert(params.margin, 'Parameter margin is required');
     assert(params.symbol, 'Parameter symbol is required');
 
-    return await this.request.post('/position/change-position-margin', params);
+    return await this.request.post('position/change-position-margin', params);
   }
 
   async setTradingStop(params) {
     assert(params, 'No params passed');
     assert(params.symbol, 'Parameter symbol is required');
 
-    return await this.request.post('/open-api/position/trading-stop', params);
+    return await this.request.post('open-api/position/trading-stop', params);
   }
 
   async getWalletFundRecords(params) {
-    return await this.request.get('/open-api/wallet/fund/records', params);
+    return await this.request.get('open-api/wallet/fund/records', params);
   }
 
   async getWithdrawRecords(params) {
-    return await this.request.get('/open-api/wallet/withdraw/list', params);
+    return await this.request.get('open-api/wallet/withdraw/list', params);
   }
 
   async getWalletBalance(params) {
     assert(params, 'No params passed');
     assert(params.coin, 'Parameter coin is required');
-    return await this.request.get('/v2/private/wallet/balance', params);
+    return await this.request.get('v2/private/wallet/balance', params);
   }
 
   async setRiskLimit(params) {
@@ -155,46 +155,46 @@ module.exports = class RestClient {
     assert(params.symbol, 'Parameter symbol is required');
     assert(params.risk_id, 'Parameter risk_id is required');
 
-    return await this.request.post('/open-api/wallet/risk-limit', params);
+    return await this.request.post('open-api/wallet/risk-limit', params);
   }
 
   async getRiskLimitList() {
-    return await this.request.get('/open-api/wallet/risk-limit/list');
+    return await this.request.get('open-api/wallet/risk-limit/list');
   }
 
   async getLastFundingRate(params) {
     assert(params, 'No params passed');
     assert(params.symbol, 'Parameter symbol is required');
 
-    return await this.request.get('/open-api/funding/prev-funding-rate', params);
+    return await this.request.get('open-api/funding/prev-funding-rate', params);
   }
 
   async getMyLastFundingFee(params) {
     assert(params, 'No params passed');
     assert(params.symbol, 'Parameter symbol is required');
 
-    return await this.request.get('/open-api/funding/prev-funding', params);
+    return await this.request.get('open-api/funding/prev-funding', params);
   }
 
   async getPredictedFunding(params) {
     assert(params, 'No params passed');
     assert(params.symbol, 'Parameter symbol is required');
 
-    return await this.request.get('/open-api/funding/predicted-funding', params);
+    return await this.request.get('open-api/funding/predicted-funding', params);
   }
 
   async getTradeRecords(params) {
     assert(params, 'No params passed');
     assert(params.order_id || params.symbol, 'Parameter order_id OR symbol is required');
 
-    return await this.request.get('/v2/private/execution/list', params);
+    return await this.request.get('v2/private/execution/list', params);
   }
 
   async getOrderBook(params) {
     assert(params, 'No params passed');
     assert(params.symbol, 'Parameter symbol is required');
 
-    return await this.request.get('/v2/public/orderBook/L2', params);
+    return await this.request.get('v2/public/orderBook/L2', params);
   }
 
   async getKline(params) {
@@ -203,30 +203,30 @@ module.exports = class RestClient {
     assert(params.interval, 'Parameter interval is required');
     assert(params.from, 'Parameter from is required');
 
-    return await this.request.get('/v2/public/kline/list', params);
+    return await this.request.get('v2/public/kline/list', params);
   }
 
   async getLatestInformation() {
-    return await this.request.get('/v2/public/tickers');
+    return await this.request.get('v2/public/tickers');
   }
 
   async getPublicTradingRecords(params) {
     assert(params, 'No params passed');
     assert(params.symbol, 'Parameter symbol is required');
 
-    return await this.request.get('/v2/public/trading-records', params);
+    return await this.request.get('v2/public/trading-records', params);
   }
 
   async getServerTime() {
-    return await this.request.get('/v2/public/time');
+    return await this.request.get('v2/public/time');
   }
 
   async getApiAnnouncements() {
-    return await this.request.get('/v2/public/announcement');
+    return await this.request.get('v2/public/announcement');
   }
 
   async getSymbols() {
-    return await this.request.get('/v2/public/symbols');
+    return await this.request.get('v2/public/symbols');
   }
 
   async getTimeOffset() {

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -95,7 +95,7 @@ module.exports = class RestClient {
     assert(params.stop_order_id || params.order_link_id, 'Parameter order_id OR order_link_id is required');
     assert(params.symbol, 'Parameter symbol is required');
 
-    return await this.request.get('GET /v2/private/stop-order', params);
+    return await this.request.get('v2/private/stop-order', params);
   }
 
   async getUserLeverage() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pxtrn/bybit-api",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "An unofficial node.js lowlevel wrapper for the Bybit Cryptocurrency Derivative exchange API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes #13. The way endpoints are joined onto the base URLs is causing double-slashes. Seems recently the testnet environment started rejecting this with 404 errors (#12).

PR summary:
- [x] Fix endpoints to always start without a slash.
- [x] Fix typo in one endpoint.
- [x] Catch other sources of error for HTTP requests (fixes #12 )